### PR TITLE
Allow other database users to restore backups.

### DIFF
--- a/modules/restore.py
+++ b/modules/restore.py
@@ -316,7 +316,7 @@ if restore_main_db:
     cur_main.close()
     conn_main.close()
     os.environ["PGPASSWORD"]='{}'.format(db_password_main)
-    res = os.system("pg_restore --jobs=4 -U " + db_user_main + " -Fc -c --if-exists -v -d " + db_database_main + " -h " + db_host_main + " -p " + str(db_port_main) + " postgres_metaprotocol.dump")
+    res = os.system("pg_restore --no-owner --jobs=4 -U " + db_user_main + " -Fc -c --if-exists -v -d " + db_database_main + " -h " + db_host_main + " -p " + str(db_port_main) + " postgres_metaprotocol.dump")
     if res != 0:
       print("Error restoring main db")
       exit()
@@ -347,7 +347,7 @@ if restore_brc20_db:
     cur_brc20.close()
     conn_brc20.close()
     os.environ["PGPASSWORD"]='{}'.format(db_password_brc20)
-    res = os.system("pg_restore --jobs=4 -U " + db_user_brc20 + " -Fc -c --if-exists -v -d " + db_database_brc20 + " -h " + db_host_brc20 + " -p " + str(db_port_brc20) + " postgres_brc20.dump")
+    res = os.system("pg_restore --no-owner --jobs=4 -U " + db_user_brc20 + " -Fc -c --if-exists -v -d " + db_database_brc20 + " -h " + db_host_brc20 + " -p " + str(db_port_brc20) + " postgres_brc20.dump")
     if res != 0:
       print("Error restoring brc20 db")
       exit()
@@ -374,7 +374,7 @@ if restore_bitmap_db:
     cur_bitmap.close()
     conn_bitmap.close()
     os.environ["PGPASSWORD"]='{}'.format(db_password_bitmap)
-    res = os.system("pg_restore --jobs=4 -U " + db_user_bitmap + " -Fc -c --if-exists -v -d " + db_database_bitmap + " -h " + db_host_bitmap + " -p " + str(db_port_bitmap) + " postgres_bitmap.dump")
+    res = os.system("pg_restore --no-owner --jobs=4 -U " + db_user_bitmap + " -Fc -c --if-exists -v -d " + db_database_bitmap + " -h " + db_host_bitmap + " -p " + str(db_port_bitmap) + " postgres_bitmap.dump")
     if res != 0:
       print("Error restoring bitmap db")
       exit()
@@ -401,7 +401,7 @@ if restore_sns_db:
     cur_sns.close()
     conn_sns.close()
     os.environ["PGPASSWORD"]='{}'.format(db_password_sns)
-    res = os.system("pg_restore --jobs=4 -U " + db_user_sns + " -Fc -c --if-exists -v -d " + db_database_sns + " -h " + db_host_sns + " -p " + str(db_port_sns) + " postgres_sns.dump")
+    res = os.system("pg_restore --no-owner --jobs=4 -U " + db_user_sns + " -Fc -c --if-exists -v -d " + db_database_sns + " -h " + db_host_sns + " -p " + str(db_port_sns) + " postgres_sns.dump")
     if res != 0:
       print("Error restoring sns db")
       exit()


### PR DESCRIPTION
In the current script, using a non-postgres user will result in restore failure.

This error is usually caused by attempting to restore a backup file that contains settings for specific roles.

Adding --no-owner will make it successful and ensure that subsequent synchronization can proceed normally.

```
pg_restore: processing item 225 SEQUENCE block_hashes_id_seq
pg_restore: creating SEQUENCE "public.block_hashes_id_seq"
pg_restore: from TOC entry 225; 1259 41204 SEQUENCE block_hashes_id_seq postgres
pg_restore: error: could not execute query: ERROR: must be able to SET ROLE "postgres"
Command was: ALTER SEQUENCE public.block_hashes_id_seq OWNER TO postgres;

pg_restore: processing item 3449 SEQUENCE OWNED BY block_hashes_id_seq
pg_restore: creating SEQUENCE OWNED BY "public.block_hashes_id_seq"
pg_restore: processing item 224 TABLE ord_content
pg_restore: creating TABLE "public.ord_content"
pg_restore: from TOC entry 224; 1259 41194 TABLE ord_content postgres
pg_restore: error: could not execute query: ERROR: must be able to SET ROLE "postgres"
Command was: ALTER TABLE public.ord_content OWNER TO postgres;

pg_restore: processing item 223 SEQUENCE ord_content_id_seq
pg_restore: creating SEQUENCE "public.ord_content_id_seq"
pg_restore: from TOC entry 223; 1259 41193 SEQUENCE ord_content_id_seq postgres
pg_restore: error: could not execute query: ERROR: must be able to SET ROLE "postgres"
Command was: ALTER SEQUENCE public.ord_content_id_seq OWNER TO postgres;
```