### PR TITLE
feat: add none-interactive default value

### DIFF
--- a/modules/restore.py
+++ b/modules/restore.py
@@ -9,7 +9,7 @@
 ## apt install postgresql-client-14
 ## apt install pbzip2
 
-import os, psycopg2
+import os, psycopg2, sys
 from dotenv import dotenv_values
 import pathlib
 
@@ -19,19 +19,21 @@ from botocore.client import Config
 
 from tqdm import tqdm
 
-def get_yn(question):
-  while True:
-    res = input(question + " (y/n):")
-    if res == 'y':
-      return True
-    elif res == 'n':
-      return False
-    else:
-      print("Invalid input")
+def get_yn(question, default=None):
+    if not sys.stdin.isatty():
+        return default
+    while True:
+        res = input(question + " (y/n): ")
+        if res.lower() == 'y':
+            return True
+        elif res.lower() == 'n':
+            return False
+        else:
+            print("Invalid input")
 
-index_brc20 = get_yn("Will you index brc20")
-index_bitmap = get_yn("Will you index bitmap")
-index_sns = get_yn("Will you index sns")
+index_brc20 = get_yn("Will you index brc20", True)
+index_bitmap = get_yn("Will you index bitmap", True)
+index_sns = get_yn("Will you index sns", True)
 
 if not os.path.isfile('main_index/.env'):
   print("main_index/.env file not found, please run reset_init.py from main_index folder")
@@ -151,9 +153,9 @@ if index_sns:
     print("Error connecting to sns db, check sns_index/.env file")
     exit()
 
-download_only = not get_yn("Do you want to restore databases (y) or download backups only (n)?")
+download_only = not get_yn("Do you want to restore databases (y) or download backups only (n)?", True)
 
-restore_index_redb = get_yn("Do you want to restore index.redb?")
+restore_index_redb = get_yn("Do you want to restore index.redb?", True)
 if not download_only and restore_index_redb:
   res = os.system('tar --help >/dev/null 2>&1')
   if res != 0:
@@ -161,16 +163,16 @@ if not download_only and restore_index_redb:
     exit()
   res = os.system('pbzip2 -V >/dev/null 2>&1')
   if res != 0:
-    res = get_yn("pbzip2 is not installed, will use normal tar, may take around 40 mins with normal tar, it'll take around 5 mins with pbzip2. Do you want to continue?")
+    res = get_yn("pbzip2 is not installed, will use normal tar, may take around 40 mins with normal tar, it'll take around 5 mins with pbzip2. Do you want to continue?", False)
     if not res:
       exit()
-restore_main_db = get_yn("Do you want to restore main db?")
+restore_main_db = get_yn("Do you want to restore main db?", True)
 restore_brc20_db = False
-if index_brc20: restore_brc20_db = get_yn("Do you want to restore brc20 db?")
+if index_brc20: restore_brc20_db = get_yn("Do you want to restore brc20 db?", True)
 restore_bitmap_db = False
-if index_bitmap: restore_bitmap_db = get_yn("Do you want to restore bitmap db?")
+if index_bitmap: restore_bitmap_db = get_yn("Do you want to restore bitmap db?", True)
 restore_sns_db = False
-if index_sns: restore_sns_db = get_yn("Do you want to restore sns db?")
+if index_sns: restore_sns_db = get_yn("Do you want to restore sns db?", True)
 if not download_only and (restore_main_db or restore_brc20_db or restore_bitmap_db or restore_sns_db):
   res = os.system('pg_restore -V >/dev/null 2>&1')
   if res != 0:


### PR DESCRIPTION
This PR added a default to various questions when current tty is not interactive. It is used for automated provision of the OPI infra. 

a IaC repo is published at: https://github.com/alexgo-io/OPI-infra/ which packs it into a docker image at: [Dockerfile](https://github.com/alexgo-io/OPI-infra/blob/main/docker/opi/Dockerfile#L57). 

this repo is using packer and pulumi to provision OPI infra. 