### PR TITLE
Several improvements for performance and future upgradeability of the OPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,17 +21,18 @@ In addition to indexing all events, it also calculates a block hash and cumulati
 
 EVENT_SEPARATOR = '|'
 ## max_supply, limit_per_mint, amount decimal count is the same as ticker's decimals (no trailing dot if decimals is 0)
-## tickers are lowercase
+## ticker_lowercase = lower(ticker)
+## ticker_original is the ticker on inscription
 for event in block_events:
   if event is 'deploy-inscribe':
-    block_str += 'deploy-inscribe;<inscr_id>;<deployer_pkscript>;<ticker>;<max_supply>;<decimals>;<limit_per_mint>' + EVENT_SEPARATOR
+    block_str += 'deploy-inscribe;<inscr_id>;<deployer_pkscript>;<ticker>;<ticker_original>;<max_supply>;<decimals>;<limit_per_mint>' + EVENT_SEPARATOR
   if event is 'mint-inscribe':
-    block_str += 'mint-inscribe;<inscr_id>;<minter_pkscript>;<ticker>;<amount>' + EVENT_SEPARATOR
+    block_str += 'mint-inscribe;<inscr_id>;<minter_pkscript>;<ticker>;<ticker_original>;<amount>' + EVENT_SEPARATOR
   if event is 'transfer-inscribe':
-    block_str += 'transfer-inscribe;<inscr_id>;<source_pkscript>;<ticker>;<amount>' + EVENT_SEPARATOR
+    block_str += 'transfer-inscribe;<inscr_id>;<source_pkscript>;<ticker>;<ticker_original>;<amount>' + EVENT_SEPARATOR
   if event is 'transfer-transfer':
     ## if sent as fee, sent_pkscript is empty
-    block_str += 'transfer-transfer;<inscr_id>;<source_pkscript>;<sent_pkscript>;<ticker>;<amount>' + EVENT_SEPARATOR
+    block_str += 'transfer-transfer;<inscr_id>;<source_pkscript>;<sent_pkscript>;<ticker>;<ticker_original>;<amount>' + EVENT_SEPARATOR
 
 if block_str.last is EVENT_SEPARATOR: block_str.remove_last()
 block_hash = sha256_hex(block_str)

--- a/README.md
+++ b/README.md
@@ -25,14 +25,14 @@ EVENT_SEPARATOR = '|'
 ## ticker_original is the ticker on inscription
 for event in block_events:
   if event is 'deploy-inscribe':
-    block_str += 'deploy-inscribe;<inscr_id>;<deployer_pkscript>;<ticker>;<ticker_original>;<max_supply>;<decimals>;<limit_per_mint>' + EVENT_SEPARATOR
+    block_str += 'deploy-inscribe;<inscr_id>;<deployer_pkscript>;<ticker_lowercase>;<ticker_original>;<max_supply>;<decimals>;<limit_per_mint>;<is_self_mint("true" or "false")>' + EVENT_SEPARATOR
   if event is 'mint-inscribe':
-    block_str += 'mint-inscribe;<inscr_id>;<minter_pkscript>;<ticker>;<ticker_original>;<amount>' + EVENT_SEPARATOR
+    block_str += 'mint-inscribe;<inscr_id>;<minter_pkscript>;<ticker_lowercase>;<ticker_original>;<amount>;<parent_id("" if null)>' + EVENT_SEPARATOR
   if event is 'transfer-inscribe':
-    block_str += 'transfer-inscribe;<inscr_id>;<source_pkscript>;<ticker>;<ticker_original>;<amount>' + EVENT_SEPARATOR
+    block_str += 'transfer-inscribe;<inscr_id>;<source_pkscript>;<ticker_lowercase>;<ticker_original>;<amount>' + EVENT_SEPARATOR
   if event is 'transfer-transfer':
     ## if sent as fee, sent_pkscript is empty
-    block_str += 'transfer-transfer;<inscr_id>;<source_pkscript>;<sent_pkscript>;<ticker>;<ticker_original>;<amount>' + EVENT_SEPARATOR
+    block_str += 'transfer-transfer;<inscr_id>;<source_pkscript>;<sent_pkscript>;<ticker_lowercase>;<ticker_original>;<amount>' + EVENT_SEPARATOR
 
 if block_str.last is EVENT_SEPARATOR: block_str.remove_last()
 block_hash = sha256_hex(block_str)

--- a/modules/bitmap_index/bitmap_index.py
+++ b/modules/bitmap_index/bitmap_index.py
@@ -248,7 +248,7 @@ try:
   else:
     db_version = cur.fetchone()[0]
     if db_version != DB_VERSION:
-      print("This version (" + db_version + ") cannot be fixed, please run reset_init.py")
+      print("This version (" + str(db_version) + ") cannot be fixed, please run reset_init.py")
       exit(1)
 except:
   print("Indexer version not found, db needs to be recreated from scratch, please run reset_init.py")

--- a/modules/bitmap_index/bitmap_index.py
+++ b/modules/bitmap_index/bitmap_index.py
@@ -82,6 +82,23 @@ if network_type_db != network_type:
   print("network_type mismatch between main index and bitmap index")
   sys.exit(1)
 
+cur_metaprotocol.execute('SELECT event_type, max_transfer_cnt from ord_transfer_counts;')
+if cur_metaprotocol.rowcount == 0:
+  print("ord_transfer_counts not found, please run index.js in main_index to fix db")
+  sys.exit(1)
+
+default_max_transfer_cnt = 0
+tx_limits = cur_metaprotocol.fetchall()
+for tx_limit in tx_limits:
+  if tx_limit[0] == 'default':
+    default_max_transfer_cnt = tx_limit[1]
+    break
+
+if default_max_transfer_cnt < 1:
+  print("default max_transfer_cnt is less than 1, bitmap_indexer requires at least 1, please recreate db from scratch and rerun ord with default tx limit set to 1 or more")
+  sys.exit(1)
+
+
 ## helper functions
 def get_bitmap_number(content_hex):
   content = None

--- a/modules/brc20_api/api.js
+++ b/modules/brc20_api/api.js
@@ -66,6 +66,17 @@ app.get('/v1/brc20/db_version', async (request, response) => {
   }
 })
 
+app.get('/v1/brc20/event_hash_version', async (request, response) => {
+  try {
+    console.log(`${request.protocol}://${request.get('host')}${request.originalUrl}`)
+    let res = await query_db('SELECT event_hash_version FROM brc20_indexer_version;')
+    response.send(res.db_version + '')
+  } catch (err) {
+    console.log(err)
+    response.status(500).send({ error: 'internal error', result: null })
+  }
+})
+
 async function get_block_height_of_db() {
   try {
     let res = await query_db('SELECT max(block_height) as max_block_height FROM brc20_block_hashes;')

--- a/modules/brc20_api/api.js
+++ b/modules/brc20_api/api.js
@@ -55,6 +55,17 @@ async function query_db(query, params = []) {
   return await db_pool.query(query, params)
 }
 
+app.get('/v1/brc20/db_version', async (request, response) => {
+  try {
+    console.log(`${request.protocol}://${request.get('host')}${request.originalUrl}`)
+    let res = await query_db('SELECT db_version FROM brc20_indexer_version;')
+    response.send(res.db_version + '')
+  } catch (err) {
+    console.log(err)
+    response.status(500).send({ error: 'internal error', result: null })
+  }
+})
+
 async function get_block_height_of_db() {
   try {
     let res = await query_db('SELECT max(block_height) as max_block_height FROM brc20_block_hashes;')

--- a/modules/brc20_api/api.js
+++ b/modules/brc20_api/api.js
@@ -70,7 +70,7 @@ app.get('/v1/brc20/event_hash_version', async (request, response) => {
   try {
     console.log(`${request.protocol}://${request.get('host')}${request.originalUrl}`)
     let res = await query_db('SELECT event_hash_version FROM brc20_indexer_version;')
-    response.send(res.db_version + '')
+    response.send(res.event_hash_version + '')
   } catch (err) {
     console.log(err)
     response.status(500).send({ error: 'internal error', result: null })

--- a/modules/brc20_api/api.js
+++ b/modules/brc20_api/api.js
@@ -59,7 +59,7 @@ app.get('/v1/brc20/db_version', async (request, response) => {
   try {
     console.log(`${request.protocol}://${request.get('host')}${request.originalUrl}`)
     let res = await query_db('SELECT db_version FROM brc20_indexer_version;')
-    response.send(res.db_version + '')
+    response.send(res.rows[0].db_version + '')
   } catch (err) {
     console.log(err)
     response.status(500).send({ error: 'internal error', result: null })
@@ -70,7 +70,7 @@ app.get('/v1/brc20/event_hash_version', async (request, response) => {
   try {
     console.log(`${request.protocol}://${request.get('host')}${request.originalUrl}`)
     let res = await query_db('SELECT event_hash_version FROM brc20_indexer_version;')
-    response.send(res.event_hash_version + '')
+    response.send(res.rows[0].event_hash_version + '')
   } catch (err) {
     console.log(err)
     response.status(500).send({ error: 'internal error', result: null })

--- a/modules/brc20_index/brc20_index.py
+++ b/modules/brc20_index/brc20_index.py
@@ -57,6 +57,14 @@ first_inscription_heights = {
 }
 first_inscription_height = first_inscription_heights[network_type]
 
+first_brc20_heights = {
+  'mainnet': 779832,
+  'testnet': 2413343,
+  'signet': 112402,
+  'regtest': 0,
+}
+first_brc20_height = first_brc20_heights[network_type]
+
 if network_type == 'regtest':
   report_to_indexer = False
   print("Network type is regtest, reporting to indexer is disabled.")
@@ -140,7 +148,11 @@ def is_positive_number(s, do_strip=False):
         if ord(ch) > ord('9') or ord(ch) < ord('0'):
           return False
       return True
+    except KeyboardInterrupt:
+      raise KeyboardInterrupt
     except: return False
+  except KeyboardInterrupt:
+    raise KeyboardInterrupt
   except: return False ## has to be a string
 
 def is_positive_number_with_dot(s, do_strip=False):
@@ -158,7 +170,11 @@ def is_positive_number_with_dot(s, do_strip=False):
           if dotFound: return False
           dotFound = True
       return True
+    except KeyboardInterrupt:
+      raise KeyboardInterrupt
     except: return False
+  except KeyboardInterrupt:
+    raise KeyboardInterrupt
   except: return False ## has to be a string
 
 def get_number_extended_to_18_decimals(s, decimals, do_strip=False):
@@ -174,14 +190,6 @@ def get_number_extended_to_18_decimals(s, decimals, do_strip=False):
     return int(normal_part + decimals_part)
   else:
     return int(s) * 10 ** 18
-
-def is_used_or_invalid(inscription_id):
-  global event_types
-  cur.execute('''select coalesce(sum(case when event_type = %s then 1 else 0 end), 0) as inscr_cnt,
-                        coalesce(sum(case when event_type = %s then 1 else 0 end), 0) as transfer_cnt
-                        from brc20_events where inscription_id = %s;''', (event_types["transfer-inscribe"], event_types["transfer-transfer"], inscription_id,))
-  row = cur.fetchall()[0]
-  return (row[0] != 1) or (row[1] != 0)
 
 def fix_numstr_decimals(num_str, decimals):
   if len(num_str) <= 18:
@@ -295,15 +303,61 @@ def check_available_balance(pkScript, tick, amount):
   if available_balance < amount: return False
   return True
 
+
+transfer_validity_cache = {}
+def is_used_or_invalid(inscription_id):
+  global event_types, transfer_validity_cache
+  if inscription_id in transfer_validity_cache:
+    return transfer_validity_cache[inscription_id] != 1
+  cur.execute('''select coalesce(sum(case when event_type = %s then 1 else 0 end), 0) as inscr_cnt,
+                        coalesce(sum(case when event_type = %s then 1 else 0 end), 0) as transfer_cnt
+                        from brc20_events where inscription_id = %s;''', (event_types["transfer-inscribe"], event_types["transfer-transfer"], inscription_id,))
+  row = cur.fetchall()[0]
+  if row[0] != 1:
+    transfer_validity_cache[inscription_id] = 0 ## invalid transfer (no inscribe event)
+    return True
+  elif row[1] != 0:
+    transfer_validity_cache[inscription_id] = -1 ## used
+    return True
+  else:
+    transfer_validity_cache[inscription_id] = 1 ## valid
+    return False
+
+def set_transfer_as_used(inscription_id):
+  global transfer_validity_cache
+  transfer_validity_cache[inscription_id] = -1
+
+def set_transfer_as_valid(inscription_id):
+  global transfer_validity_cache
+  transfer_validity_cache[inscription_id] = 1
+
 def reset_caches():
-  global balance_cache, transfer_inscribe_event_cache
+  global balance_cache, transfer_inscribe_event_cache, ticks, transfer_validity_cache
   balance_cache = {}
   transfer_inscribe_event_cache = {}
+  transfer_validity_cache = {}
+  sttm = time.time()
+  cur.execute('''select tick, remaining_supply, limit_per_mint, decimals, is_self_mint, deploy_inscription_id from brc20_tickers;''')
+  ticks_ = cur.fetchall()
+  ticks = {}
+  for t in ticks_:
+    ticks[t[0]] = [t[1], t[2], t[3], t[4], t[5]]
+  print("Ticks refreshed in " + str(time.time() - sttm) + " seconds")
+
+block_start_max_event_id = None
+brc20_events_insert_sql = '''insert into brc20_events (id, event_type, block_height, inscription_id, event) values '''
+brc20_events_insert_cache = []
+brc20_tickers_insert_sql = '''insert into brc20_tickers (tick, original_tick, max_supply, decimals, limit_per_mint, remaining_supply, block_height, is_self_mint, deploy_inscription_id) values '''
+brc20_tickers_insert_cache = []
+brc20_tickers_remaining_supply_update_sql = '''update brc20_tickers set remaining_supply = remaining_supply - %s where tick = %s;'''
+brc20_tickers_remaining_supply_update_cache = {}
+brc20_tickers_burned_supply_update_sql = '''update brc20_tickers set burned_supply = burned_supply + %s where tick = %s;'''
+brc20_tickers_burned_supply_update_cache = {}
+brc20_historic_balances_insert_sql = '''insert into brc20_historic_balances (pkscript, wallet, tick, overall_balance, available_balance, block_height, event_id) values '''
+brc20_historic_balances_insert_cache = []
 
 def deploy_inscribe(block_height, inscription_id, deployer_pkScript, deployer_wallet, tick, original_tick, max_supply, decimals, limit_per_mint, is_self_mint):
   global ticks, in_commit, block_events_str, event_types
-  cur.execute("BEGIN;")
-  in_commit = True
 
   event = {
     "deployer_pkScript": deployer_pkScript,
@@ -316,20 +370,15 @@ def deploy_inscribe(block_height, inscription_id, deployer_pkScript, deployer_wa
     "is_self_mint": str(is_self_mint)
   }
   block_events_str += get_event_str(event, "deploy-inscribe", inscription_id) + EVENT_SEPARATOR
-  cur.execute('''insert into brc20_events (event_type, block_height, inscription_id, event)
-    values (%s, %s, %s, %s);''', (event_types["deploy-inscribe"], block_height, inscription_id, json.dumps(event)))
+  event_id = block_start_max_event_id + len(brc20_events_insert_cache) + 1
+  brc20_events_insert_cache.append((event_id, event_types["deploy-inscribe"], block_height, inscription_id, json.dumps(event)))
   
-  cur.execute('''insert into brc20_tickers (tick, original_tick, max_supply, decimals, limit_per_mint, remaining_supply, block_height, is_self_mint, deploy_inscription_id)
-    values (%s, %s, %s, %s, %s, %s, %s, %s, %s);''', (tick, original_tick, max_supply, decimals, limit_per_mint, max_supply, block_height, is_self_mint == "true", inscription_id))
+  brc20_tickers_insert_cache.append((tick, original_tick, max_supply, decimals, limit_per_mint, max_supply, block_height, is_self_mint == "true", inscription_id))
   
-  cur.execute("COMMIT;")
-  in_commit = False
   ticks[tick] = [max_supply, limit_per_mint, decimals, is_self_mint == "true", inscription_id]
 
 def mint_inscribe(block_height, inscription_id, minted_pkScript, minted_wallet, tick, original_tick, amount, parent_id):
   global ticks, in_commit, block_events_str, event_types
-  cur.execute("BEGIN;")
-  in_commit = True
 
   event = {
     "minted_pkScript": minted_pkScript,
@@ -340,26 +389,19 @@ def mint_inscribe(block_height, inscription_id, minted_pkScript, minted_wallet, 
     "parent_id": parent_id
   }
   block_events_str += get_event_str(event, "mint-inscribe", inscription_id) + EVENT_SEPARATOR
-  cur.execute('''insert into brc20_events (event_type, block_height, inscription_id, event)
-    values (%s, %s, %s, %s) returning id;''', (event_types["mint-inscribe"], block_height, inscription_id, json.dumps(event)))
-  event_id = cur.fetchone()[0]
-  cur.execute('''update brc20_tickers set remaining_supply = remaining_supply - %s where tick = %s;''', (amount, tick))
+  event_id = block_start_max_event_id + len(brc20_events_insert_cache) + 1
+  brc20_events_insert_cache.append((event_id, event_types["mint-inscribe"], block_height, inscription_id, json.dumps(event)))
+  brc20_tickers_remaining_supply_update_cache[tick] = brc20_tickers_remaining_supply_update_cache.get(tick, 0) + amount
 
   last_balance = get_last_balance(minted_pkScript, tick)
   last_balance["overall_balance"] += amount
   last_balance["available_balance"] += amount
-  cur.execute('''insert into brc20_historic_balances (pkscript, wallet, tick, overall_balance, available_balance, block_height, event_id) 
-                values (%s, %s, %s, %s, %s, %s, %s);''', 
-                (minted_pkScript, minted_wallet, tick, last_balance["overall_balance"], last_balance["available_balance"], block_height, event_id))
+  brc20_historic_balances_insert_cache.append((minted_pkScript, minted_wallet, tick, last_balance["overall_balance"], last_balance["available_balance"], block_height, event_id))
   
-  cur.execute("COMMIT;")
-  in_commit = False
   ticks[tick][0] -= amount
 
 def transfer_inscribe(block_height, inscription_id, source_pkScript, source_wallet, tick, original_tick, amount):
   global in_commit, block_events_str, event_types
-  cur.execute("BEGIN;")
-  in_commit = True
 
   event = {
     "source_pkScript": source_pkScript,
@@ -369,24 +411,18 @@ def transfer_inscribe(block_height, inscription_id, source_pkScript, source_wall
     "amount": str(amount)
   }
   block_events_str += get_event_str(event, "transfer-inscribe", inscription_id) + EVENT_SEPARATOR
-  cur.execute('''insert into brc20_events (event_type, block_height, inscription_id, event)
-    values (%s, %s, %s, %s) returning id;''', (event_types["transfer-inscribe"], block_height, inscription_id, json.dumps(event)))
-  event_id = cur.fetchone()[0]
+  event_id = block_start_max_event_id + len(brc20_events_insert_cache) + 1
+  brc20_events_insert_cache.append((event_id, event_types["transfer-inscribe"], block_height, inscription_id, json.dumps(event)))
+  set_transfer_as_valid(inscription_id)
   
   last_balance = get_last_balance(source_pkScript, tick)
   last_balance["available_balance"] -= amount
-  cur.execute('''insert into brc20_historic_balances (pkscript, wallet, tick, overall_balance, available_balance, block_height, event_id)
-                values (%s, %s, %s, %s, %s, %s, %s);''', 
-                (source_pkScript, source_wallet, tick, last_balance["overall_balance"], last_balance["available_balance"], block_height, event_id))
+  brc20_historic_balances_insert_cache.append((source_pkScript, source_wallet, tick, last_balance["overall_balance"], last_balance["available_balance"], block_height, event_id))
   
-  cur.execute("COMMIT;")
-  in_commit = False
   save_transfer_inscribe_event(inscription_id, event)
 
 def transfer_transfer_normal(block_height, inscription_id, spent_pkScript, spent_wallet, tick, original_tick, amount, using_tx_id):
   global in_commit, block_events_str, event_types
-  cur.execute("BEGIN;")
-  in_commit = True
 
   inscribe_event = get_transfer_inscribe_event(inscription_id)
   source_pkScript = inscribe_event["source_pkScript"]
@@ -402,34 +438,25 @@ def transfer_transfer_normal(block_height, inscription_id, spent_pkScript, spent
     "using_tx_id": str(using_tx_id)
   }
   block_events_str += get_event_str(event, "transfer-transfer", inscription_id) + EVENT_SEPARATOR
-  cur.execute('''insert into brc20_events (event_type, block_height, inscription_id, event)
-    values (%s, %s, %s, %s) returning id;''', (event_types["transfer-transfer"], block_height, inscription_id, json.dumps(event)))
-  event_id = cur.fetchone()[0]
+  event_id = block_start_max_event_id + len(brc20_events_insert_cache) + 1
+  brc20_events_insert_cache.append((event_id, event_types["transfer-transfer"], block_height, inscription_id, json.dumps(event)))
+  set_transfer_as_used(inscription_id)
   
   last_balance = get_last_balance(source_pkScript, tick)
   last_balance["overall_balance"] -= amount
-  cur.execute('''insert into brc20_historic_balances (pkscript, wallet, tick, overall_balance, available_balance, block_height, event_id)
-                values (%s, %s, %s, %s, %s, %s, %s);''', 
-                (source_pkScript, source_wallet, tick, last_balance["overall_balance"], last_balance["available_balance"], block_height, event_id))
+  brc20_historic_balances_insert_cache.append((source_pkScript, source_wallet, tick, last_balance["overall_balance"], last_balance["available_balance"], block_height, event_id))
   
   if spent_pkScript != source_pkScript:
     last_balance = get_last_balance(spent_pkScript, tick)
   last_balance["overall_balance"] += amount
   last_balance["available_balance"] += amount
-  cur.execute('''insert into brc20_historic_balances (pkscript, wallet, tick, overall_balance, available_balance, block_height, event_id) 
-                values (%s, %s, %s, %s, %s, %s, %s);''', 
-                (spent_pkScript, spent_wallet, tick, last_balance["overall_balance"], last_balance["available_balance"], block_height, -1 * event_id)) ## negated to make a unique event_id
+  brc20_historic_balances_insert_cache.append((spent_pkScript, spent_wallet, tick, last_balance["overall_balance"], last_balance["available_balance"], block_height, -1 * event_id)) ## negated to make a unique event_id
   
   if spent_pkScript == '6a':
-    cur.execute('''update brc20_tickers set burned_supply = burned_supply + %s where tick = %s;''', (amount, tick))
-
-  cur.execute("COMMIT;")
-  in_commit = False
+    brc20_tickers_burned_supply_update_cache[tick] = brc20_tickers_burned_supply_update_cache.get(tick, 0) + amount
 
 def transfer_transfer_spend_to_fee(block_height, inscription_id, tick, original_tick, amount, using_tx_id):
   global in_commit, block_events_str, event_types
-  cur.execute("BEGIN;")
-  in_commit = True
 
   inscribe_event = get_transfer_inscribe_event(inscription_id)
   source_pkScript = inscribe_event["source_pkScript"]
@@ -445,18 +472,13 @@ def transfer_transfer_spend_to_fee(block_height, inscription_id, tick, original_
     "using_tx_id": str(using_tx_id)
   }
   block_events_str += get_event_str(event, "transfer-transfer", inscription_id) + EVENT_SEPARATOR
-  cur.execute('''insert into brc20_events (event_type, block_height, inscription_id, event)
-    values (%s, %s, %s, %s) returning id;''', (event_types["transfer-transfer"], block_height, inscription_id, json.dumps(event)))
-  event_id = cur.fetchone()[0]
+  event_id = block_start_max_event_id + len(brc20_events_insert_cache) + 1
+  brc20_events_insert_cache.append((event_id, event_types["transfer-transfer"], block_height, inscription_id, json.dumps(event)))
+  set_transfer_as_used(inscription_id)
   
   last_balance = get_last_balance(source_pkScript, tick)
   last_balance["available_balance"] += amount
-  cur.execute('''insert into brc20_historic_balances (pkscript, wallet, tick, overall_balance, available_balance, block_height, event_id) 
-                values (%s, %s, %s, %s, %s, %s, %s);''', 
-                (source_pkScript, source_wallet, tick, last_balance["overall_balance"], last_balance["available_balance"], block_height, event_id))
-  
-  cur.execute("COMMIT;")
-  in_commit = False
+  brc20_historic_balances_insert_cache.append((source_pkScript, source_wallet, tick, last_balance["overall_balance"], last_balance["available_balance"], block_height, event_id))
 
 
 def update_event_hashes(block_height):
@@ -470,12 +492,17 @@ def update_event_hashes(block_height):
   else:
     cumulative_event_hash = get_sha256_hash(cur.fetchone()[0] + block_event_hash)
   cur.execute('''INSERT INTO brc20_cumulative_event_hashes (block_height, block_event_hash, cumulative_event_hash) VALUES (%s, %s, %s);''', (block_height, block_event_hash, cumulative_event_hash))
-    
 
 def index_block(block_height, current_block_hash):
-  global ticks, block_events_str
+  global ticks, block_events_str, block_start_max_event_id, brc20_events_insert_cache, brc20_tickers_insert_cache, brc20_tickers_remaining_supply_update_cache, brc20_tickers_burned_supply_update_cache, brc20_historic_balances_insert_cache, in_commit
   print("Indexing block " + str(block_height))
   block_events_str = ""
+
+  if block_height < first_brc20_height:
+    print("Block height is before first brc20 height, skipping")
+    update_event_hashes(block_height)
+    cur.execute('''INSERT INTO brc20_block_hashes (block_height, block_hash) VALUES (%s, %s);''', (block_height, current_block_hash))
+    return
   
   cur_metaprotocol.execute('''SELECT ot.id, ot.inscription_id, ot.old_satpoint, ot.new_pkscript, ot.new_wallet, ot.sent_as_fee, oc."content", oc.content_type, onti.parent_id
                               FROM ord_transfers ot
@@ -493,14 +520,13 @@ def index_block(block_height, current_block_hash):
     return
   print("Transfer count: ", len(transfers))
 
-  ## refresh ticks
-  sttm = time.time()
-  cur.execute('''select tick, remaining_supply, limit_per_mint, decimals, is_self_mint, deploy_inscription_id from brc20_tickers;''')
-  ticks_ = cur.fetchall()
-  ticks = {}
-  for t in ticks_:
-    ticks[t[0]] = [t[1], t[2], t[3], t[4], t[5]]
-  print("Ticks refreshed in " + str(time.time() - sttm) + " seconds")
+  cur.execute('''select COALESCE(max(id), -1) from brc20_events;''')
+  block_start_max_event_id = cur.fetchone()[0]
+  brc20_events_insert_cache = []
+  brc20_tickers_insert_cache = []
+  brc20_tickers_remaining_supply_update_cache = {}
+  brc20_tickers_burned_supply_update_cache = {}
+  brc20_historic_balances_insert_cache = []
   
   idx = 0
   for transfer in transfers:
@@ -515,6 +541,8 @@ def index_block(block_height, current_block_hash):
 
     if content_type is None: continue ## invalid inscription
     try: content_type = codecs.decode(content_type, "hex").decode('utf-8')
+    except KeyboardInterrupt:
+      raise KeyboardInterrupt
     except: pass
     content_type = content_type.split(';')[0]
     if content_type != 'application/json' and content_type != 'text/plain': continue ## invalid inscription
@@ -524,6 +552,8 @@ def index_block(block_height, current_block_hash):
     tick = js["tick"]
     original_tick = tick
     try: tick = tick.lower()
+    except KeyboardInterrupt:
+      raise KeyboardInterrupt
     except: continue ## invalid tick
     original_tick_len = utf8len(original_tick)
     if original_tick_len != 4 and original_tick_len != 5: continue ## invalid tick
@@ -602,13 +632,39 @@ def index_block(block_height, current_block_hash):
         if sent_as_fee: transfer_transfer_spend_to_fee(block_height, inscr_id, tick, original_tick, amount, tx_id)
         else: transfer_transfer_normal(block_height, inscr_id, new_pkScript, new_addr, tick, original_tick, amount, tx_id)
   
+  cur.execute("BEGIN;")
+  in_commit = True
+  print("inserting events...")
+  execute_batch_insert(brc20_events_insert_sql, brc20_events_insert_cache, 1000)
+  print("inserting tickers...")
+  execute_batch_insert(brc20_tickers_insert_sql, brc20_tickers_insert_cache, 1000)
+  print("updating tickers remaining_supply...")
+  for tick in brc20_tickers_remaining_supply_update_cache:
+    cur.execute(brc20_tickers_remaining_supply_update_sql, (brc20_tickers_remaining_supply_update_cache[tick], tick))
+  print("updating tickers burned_supply...")
+  for tick in brc20_tickers_burned_supply_update_cache:
+    cur.execute(brc20_tickers_burned_supply_update_sql, (brc20_tickers_burned_supply_update_cache[tick], tick))
+  print("inserting historic balances...")
+  execute_batch_insert(brc20_historic_balances_insert_sql, brc20_historic_balances_insert_cache, 1000)
   update_event_hashes(block_height)
   # end of block
   cur.execute('''INSERT INTO brc20_block_hashes (block_height, block_hash) VALUES (%s, %s);''', (block_height, current_block_hash))
+  print("committing...")
+  cur.execute("COMMIT;")
+  in_commit = False
   conn.commit()
   print("ALL DONE")
 
+def execute_batch_insert(sql_start, cache, batch_size):
+  if len(cache) > 0:
+    single_elem_cnt = len(cache[0])
+    single_insert_sql_part = '(' + ','.join(['%s' for _ in range(single_elem_cnt)]) + ')'
+    for i in range(0, len(cache), batch_size):
+      elem_cnt = min(batch_size, len(cache) - i)
+      sql = sql_start + ','.join([single_insert_sql_part for _ in range(elem_cnt)]) + ';'
+      cur.execute(sql, [elem for sublist in cache[i:i+batch_size] for elem in sublist])
 
+      
 
 def check_for_reorg():
   cur.execute('select block_height, block_hash from brc20_block_hashes order by block_height desc limit 1;')
@@ -721,6 +777,13 @@ event_types_rev = {}
 for key in event_types:
   event_types_rev[event_types[key]] = key
 
+sttm = time.time()
+cur.execute('''select tick, remaining_supply, limit_per_mint, decimals, is_self_mint, deploy_inscription_id from brc20_tickers;''')
+ticks_ = cur.fetchall()
+ticks = {}
+for t in ticks_:
+  ticks[t[0]] = [t[1], t[2], t[3], t[4], t[5]]
+print("Ticks refreshed in " + str(time.time() - sttm) + " seconds")
 
 def reindex_cumulative_hashes():
   global event_types_rev, ticks
@@ -780,6 +843,8 @@ def try_to_report_with_retries(to_send):
         return
       else:
         print("Error while reporting hashes to metaprotocol indexer indexer, status code: " + str(r.status_code))
+    except KeyboardInterrupt:
+      raise KeyboardInterrupt
     except:
       print("Error while reporting hashes to metaprotocol indexer indexer, retrying...")
     time.sleep(1)
@@ -1046,6 +1111,8 @@ def check_extra_tables():
       else:
         print("extra table data index failed for block: " + str(ebh_tocheck_height))
         return
+  except KeyboardInterrupt:
+    raise KeyboardInterrupt
   except:
     traceback.print_exc()
     return
@@ -1085,12 +1152,20 @@ while True:
     continue
   try:
     index_block(current_block, current_block_hash)
-    if create_extra_tables:
+    if create_extra_tables and max_block_of_metaprotocol_db - current_block < 10: ## only update extra tables at the end of sync
       print("checking extra tables")
       check_extra_tables()
     if max_block_of_metaprotocol_db - current_block < 10 or current_block - last_report_height > 100: ## do not report if there are more than 10 blocks to index
       report_hashes(current_block)
       last_report_height = current_block
+  except KeyboardInterrupt:
+    traceback.print_exc()
+    if in_commit: ## rollback commit if any
+      print("rolling back")
+      cur.execute('''ROLLBACK;''')
+      in_commit = False
+    print("Exiting...")
+    sys.exit(1)
   except:
     traceback.print_exc()
     if in_commit: ## rollback commit if any

--- a/modules/brc20_index/brc20_index.py
+++ b/modules/brc20_index/brc20_index.py
@@ -419,6 +419,9 @@ def transfer_transfer_normal(block_height, inscription_id, spent_pkScript, spent
                 values (%s, %s, %s, %s, %s, %s, %s);''', 
                 (spent_pkScript, spent_wallet, tick, last_balance["overall_balance"], last_balance["available_balance"], block_height, -1 * event_id)) ## negated to make a unique event_id
   
+  if spent_pkScript == '6a':
+    cur.execute('''update brc20_tickers set burned_supply = burned_supply + %s where tick = %s;''', (amount, tick))
+
   cur.execute("COMMIT;")
   in_commit = False
 

--- a/modules/brc20_index/brc20_index.py
+++ b/modules/brc20_index/brc20_index.py
@@ -725,10 +725,10 @@ else:
   if db_version != DB_VERSION:
     print("Indexer version mismatch!!")
     if db_version not in RECOVERABLE_DB_VERSIONS:
-      print("This version (" + db_version + ") cannot be fixed, please run reset_init.py")
+      print("This version (" + str(db_version) + ") cannot be fixed, please run reset_init.py")
       exit(1)
     else:
-      print("This version (" + db_version + ") can be fixed, fixing in 5 secs...")
+      print("This version (" + str(db_version) + ") can be fixed, fixing in 5 secs...")
       time.sleep(5)
       reindex_cumulative_hashes()
       cur.execute('alter table brc20_indexer_version add column if not exists db_version int4;') ## next versions will use DB_VERSION for DB check

--- a/modules/brc20_index/brc20_index.py
+++ b/modules/brc20_index/brc20_index.py
@@ -19,6 +19,7 @@ EVENT_SEPARATOR = "|"
 INDEXER_VERSION = "opi-brc20-full-node v0.4.0"
 RECOVERABLE_DB_VERSIONS = [  ]
 DB_VERSION = 4
+EVENT_HASH_VERSION = 2
 
 SELF_MINT_ENABLE_HEIGHT = 837090
 
@@ -802,6 +803,7 @@ def report_hashes(block_height):
     "network_type": network_type,
     "version": INDEXER_VERSION,
     "db_version": DB_VERSION,
+    "event_hash_version": EVENT_HASH_VERSION,
     "block_height": block_height,
     "block_hash": block_hash,
     "block_event_hash": block_event_hash,

--- a/modules/brc20_index/brc20_index.py
+++ b/modules/brc20_index/brc20_index.py
@@ -201,6 +201,7 @@ def get_event_str(event, event_type, inscription_id):
     res += inscription_id + ";"
     res += event["deployer_pkScript"] + ";"
     res += event["tick"] + ";"
+    res += event["original_tick"] + ";"
     res += fix_numstr_decimals(event["max_supply"], decimals_int) + ";"
     res += event["decimals"] + ";"
     res += fix_numstr_decimals(event["limit_per_mint"], decimals_int)
@@ -211,6 +212,7 @@ def get_event_str(event, event_type, inscription_id):
     res += inscription_id + ";"
     res += event["minted_pkScript"] + ";"
     res += event["tick"] + ";"
+    res += event["original_tick"] + ";"
     res += fix_numstr_decimals(event["amount"], decimals_int)
     return res
   elif event_type == "transfer-inscribe":
@@ -219,6 +221,7 @@ def get_event_str(event, event_type, inscription_id):
     res += inscription_id + ";"
     res += event["source_pkScript"] + ";"
     res += event["tick"] + ";"
+    res += event["original_tick"] + ";"
     res += fix_numstr_decimals(event["amount"], decimals_int)
     return res
   elif event_type == "transfer-transfer":
@@ -231,6 +234,7 @@ def get_event_str(event, event_type, inscription_id):
     else:
       res += ";"
     res += event["tick"] + ";"
+    res += event["original_tick"] + ";"
     res += fix_numstr_decimals(event["amount"], decimals_int)
     return res
   else:
@@ -300,6 +304,7 @@ def deploy_inscribe(block_height, inscription_id, deployer_pkScript, deployer_wa
     "deployer_pkScript": deployer_pkScript,
     "deployer_wallet": deployer_wallet,
     "tick": tick,
+    "original_tick": original_tick,
     "max_supply": str(max_supply),
     "decimals": str(decimals),
     "limit_per_mint": str(limit_per_mint)
@@ -315,7 +320,7 @@ def deploy_inscribe(block_height, inscription_id, deployer_pkScript, deployer_wa
   in_commit = False
   ticks[tick] = [max_supply, limit_per_mint, decimals]
 
-def mint_inscribe(block_height, inscription_id, minted_pkScript, minted_wallet, tick, amount):
+def mint_inscribe(block_height, inscription_id, minted_pkScript, minted_wallet, tick, original_tick, amount):
   global ticks, in_commit, block_events_str, event_types
   cur.execute("BEGIN;")
   in_commit = True
@@ -324,6 +329,7 @@ def mint_inscribe(block_height, inscription_id, minted_pkScript, minted_wallet, 
     "minted_pkScript": minted_pkScript,
     "minted_wallet": minted_wallet,
     "tick": tick,
+    "original_tick": original_tick,
     "amount": str(amount)
   }
   block_events_str += get_event_str(event, "mint-inscribe", inscription_id) + EVENT_SEPARATOR
@@ -343,7 +349,7 @@ def mint_inscribe(block_height, inscription_id, minted_pkScript, minted_wallet, 
   in_commit = False
   ticks[tick][0] -= amount
 
-def transfer_inscribe(block_height, inscription_id, source_pkScript, source_wallet, tick, amount):
+def transfer_inscribe(block_height, inscription_id, source_pkScript, source_wallet, tick, original_tick, amount):
   global in_commit, block_events_str, event_types
   cur.execute("BEGIN;")
   in_commit = True
@@ -352,6 +358,7 @@ def transfer_inscribe(block_height, inscription_id, source_pkScript, source_wall
     "source_pkScript": source_pkScript,
     "source_wallet": source_wallet,
     "tick": tick,
+    "original_tick": original_tick,
     "amount": str(amount)
   }
   block_events_str += get_event_str(event, "transfer-inscribe", inscription_id) + EVENT_SEPARATOR
@@ -369,7 +376,7 @@ def transfer_inscribe(block_height, inscription_id, source_pkScript, source_wall
   in_commit = False
   save_transfer_inscribe_event(inscription_id, event)
 
-def transfer_transfer_normal(block_height, inscription_id, spent_pkScript, spent_wallet, tick, amount, using_tx_id):
+def transfer_transfer_normal(block_height, inscription_id, spent_pkScript, spent_wallet, tick, original_tick, amount, using_tx_id):
   global in_commit, block_events_str, event_types
   cur.execute("BEGIN;")
   in_commit = True
@@ -383,6 +390,7 @@ def transfer_transfer_normal(block_height, inscription_id, spent_pkScript, spent
     "spent_pkScript": spent_pkScript,
     "spent_wallet": spent_wallet,
     "tick": tick,
+    "original_tick": original_tick,
     "amount": str(amount),
     "using_tx_id": str(using_tx_id)
   }
@@ -408,7 +416,7 @@ def transfer_transfer_normal(block_height, inscription_id, spent_pkScript, spent
   cur.execute("COMMIT;")
   in_commit = False
 
-def transfer_transfer_spend_to_fee(block_height, inscription_id, tick, amount, using_tx_id):
+def transfer_transfer_spend_to_fee(block_height, inscription_id, tick, original_tick, amount, using_tx_id):
   global in_commit, block_events_str, event_types
   cur.execute("BEGIN;")
   in_commit = True
@@ -422,6 +430,7 @@ def transfer_transfer_spend_to_fee(block_height, inscription_id, tick, amount, u
     "spent_pkScript": None,
     "spent_wallet": None,
     "tick": tick,
+    "original_tick": original_tick,
     "amount": str(amount),
     "using_tx_id": str(using_tx_id)
   }

--- a/modules/brc20_index/brc20_index.py
+++ b/modules/brc20_index/brc20_index.py
@@ -555,7 +555,7 @@ def index_block(block_height, current_block_hash):
       if ticks[tick][1] is not None and amount > ticks[tick][1]: continue ## mint too much
       if amount > ticks[tick][0]: ## mint remaining tokens
         amount = ticks[tick][0]
-      mint_inscribe(block_height, inscr_id, new_pkScript, new_addr, tick, amount)
+      mint_inscribe(block_height, inscr_id, new_pkScript, new_addr, tick, original_tick, amount)
     
     # handle transfer
     if js["op"] == 'transfer':
@@ -570,11 +570,11 @@ def index_block(block_height, current_block_hash):
       ## check if available balance is enough
       if old_satpoint == '':
         if not check_available_balance(new_pkScript, tick, amount): continue ## not enough available balance
-        transfer_inscribe(block_height, inscr_id, new_pkScript, new_addr, tick, amount)
+        transfer_inscribe(block_height, inscr_id, new_pkScript, new_addr, tick, original_tick, amount)
       else:
         if is_used_or_invalid(inscr_id): continue ## already used or invalid
-        if sent_as_fee: transfer_transfer_spend_to_fee(block_height, inscr_id, tick, amount, tx_id)
-        else: transfer_transfer_normal(block_height, inscr_id, new_pkScript, new_addr, tick, amount, tx_id)
+        if sent_as_fee: transfer_transfer_spend_to_fee(block_height, inscr_id, tick, original_tick, amount, tx_id)
+        else: transfer_transfer_normal(block_height, inscr_id, new_pkScript, new_addr, tick, original_tick, amount, tx_id)
   
   update_event_hashes(block_height)
   # end of block

--- a/modules/brc20_index/brc20_index.py
+++ b/modules/brc20_index/brc20_index.py
@@ -319,7 +319,7 @@ def deploy_inscribe(block_height, inscription_id, deployer_pkScript, deployer_wa
     values (%s, %s, %s, %s);''', (event_types["deploy-inscribe"], block_height, inscription_id, json.dumps(event)))
   
   cur.execute('''insert into brc20_tickers (tick, original_tick, max_supply, decimals, limit_per_mint, remaining_supply, block_height, is_self_mint, deploy_inscription_id)
-    values (%s, %s, %s, %s, %s, %s, %s);''', (tick, original_tick, max_supply, decimals, limit_per_mint, max_supply, block_height, is_self_mint == "true", inscription_id))
+    values (%s, %s, %s, %s, %s, %s, %s, %s, %s);''', (tick, original_tick, max_supply, decimals, limit_per_mint, max_supply, block_height, is_self_mint == "true", inscription_id))
   
   cur.execute("COMMIT;")
   in_commit = False

--- a/modules/brc20_index/brc20_index.py
+++ b/modules/brc20_index/brc20_index.py
@@ -98,12 +98,28 @@ if create_extra_tables:
 
 cur_metaprotocol.execute('SELECT network_type from ord_network_type LIMIT 1;')
 if cur_metaprotocol.rowcount == 0:
-  print("ord_network_type not found, main db needs to be recreated from scratch or fixed with index.js, please run index.js or main_index")
+  print("ord_network_type not found, main db needs to be recreated from scratch or fixed with index.js, please run index.js in main_index")
   sys.exit(1)
 
 network_type_db = cur_metaprotocol.fetchone()[0]
 if network_type_db != network_type:
   print("network_type mismatch between main index and brc20 index")
+  sys.exit(1)
+
+cur_metaprotocol.execute('SELECT event_type, max_transfer_cnt from ord_transfer_counts;')
+if cur_metaprotocol.rowcount == 0:
+  print("ord_transfer_counts not found, please run index.js in main_index to fix db")
+  sys.exit(1)
+
+default_max_transfer_cnt = 0
+tx_limits = cur_metaprotocol.fetchall()
+for tx_limit in tx_limits:
+  if tx_limit[0] == 'default':
+    default_max_transfer_cnt = tx_limit[1]
+    break
+
+if default_max_transfer_cnt < 2:
+  print("default max_transfer_cnt is less than 2, brc20_indexer requires at least 2, please recreate db from scratch and rerun ord with default tx limit set to 2 or more")
   sys.exit(1)
 
 ## helper functions

--- a/modules/brc20_index/db_init.sql
+++ b/modules/brc20_index/db_init.sql
@@ -81,4 +81,4 @@ CREATE TABLE public.brc20_indexer_version (
 	event_hash_version int4 NOT NULL,
 	CONSTRAINT brc20_indexer_version_pk PRIMARY KEY (id)
 );
-INSERT INTO public.brc20_indexer_version (indexer_version, db_version) VALUES ('opi-brc20-full-node v0.4.0', 4, 2);
+INSERT INTO public.brc20_indexer_version (indexer_version, db_version, event_hash_version) VALUES ('opi-brc20-full-node v0.4.0', 4, 2);

--- a/modules/brc20_index/db_init.sql
+++ b/modules/brc20_index/db_init.sql
@@ -45,6 +45,8 @@ CREATE TABLE public.brc20_tickers (
 	decimals int4 NOT NULL,
 	limit_per_mint numeric(40) NOT NULL,
 	remaining_supply numeric(40) NOT NULL,
+	is_self_mint boolean NOT NULL,
+	deploy_inscription_id text NOT NULL,
 	block_height int4 NOT NULL,
 	CONSTRAINT brc20_tickers_pk PRIMARY KEY (id)
 );

--- a/modules/brc20_index/db_init.sql
+++ b/modules/brc20_index/db_init.sql
@@ -39,7 +39,7 @@ CREATE INDEX brc20_events_inscription_id_idx ON public.brc20_events USING btree 
 
 CREATE TABLE public.brc20_tickers (
 	id bigserial NOT NULL,
-	tick_original varchar(4) NOT NULL,
+	original_tick varchar(4) NOT NULL,
 	tick text NOT NULL,
 	max_supply numeric(40) NOT NULL,
 	decimals int4 NOT NULL,
@@ -48,7 +48,7 @@ CREATE TABLE public.brc20_tickers (
 	block_height int4 NOT NULL,
 	CONSTRAINT brc20_tickers_pk PRIMARY KEY (id)
 );
-CREATE UNIQUE INDEX brc20_tickers_tick_original_idx ON public.brc20_tickers USING btree (tick_original);
+CREATE UNIQUE INDEX brc20_tickers_original_tick_idx ON public.brc20_tickers USING btree (original_tick);
 CREATE UNIQUE INDEX brc20_tickers_tick_idx ON public.brc20_tickers USING btree (tick);
 
 CREATE TABLE public.brc20_cumulative_event_hashes (

--- a/modules/brc20_index/db_init.sql
+++ b/modules/brc20_index/db_init.sql
@@ -45,7 +45,7 @@ CREATE TABLE public.brc20_tickers (
 	decimals int4 NOT NULL,
 	limit_per_mint numeric(40) NOT NULL,
 	remaining_supply numeric(40) NOT NULL,
-	burned_supply numeric(40) NOT NULL,
+	burned_supply numeric(40) NOT NULL DEFAULT 0,
 	is_self_mint boolean NOT NULL,
 	deploy_inscription_id text NOT NULL,
 	block_height int4 NOT NULL,

--- a/modules/brc20_index/db_init.sql
+++ b/modules/brc20_index/db_init.sql
@@ -10,7 +10,7 @@ CREATE TABLE public.brc20_historic_balances (
 	id bigserial NOT NULL,
 	pkscript text NOT NULL,
 	wallet text NULL,
-	tick varchar(4) NOT NULL,
+	tick text NOT NULL,
 	overall_balance numeric(40) NOT NULL,
 	available_balance numeric(40) NOT NULL,
 	block_height int4 NOT NULL,
@@ -39,7 +39,8 @@ CREATE INDEX brc20_events_inscription_id_idx ON public.brc20_events USING btree 
 
 CREATE TABLE public.brc20_tickers (
 	id bigserial NOT NULL,
-	tick varchar(4) NOT NULL,
+	tick_original varchar(4) NOT NULL,
+	tick text NOT NULL,
 	max_supply numeric(40) NOT NULL,
 	decimals int4 NOT NULL,
 	limit_per_mint numeric(40) NOT NULL,
@@ -47,6 +48,7 @@ CREATE TABLE public.brc20_tickers (
 	block_height int4 NOT NULL,
 	CONSTRAINT brc20_tickers_pk PRIMARY KEY (id)
 );
+CREATE UNIQUE INDEX brc20_tickers_tick_original_idx ON public.brc20_tickers USING btree (tick_original);
 CREATE UNIQUE INDEX brc20_tickers_tick_idx ON public.brc20_tickers USING btree (tick);
 
 CREATE TABLE public.brc20_cumulative_event_hashes (
@@ -75,4 +77,4 @@ CREATE TABLE public.brc20_indexer_version (
 	db_version int4 NOT NULL,
 	CONSTRAINT brc20_indexer_version_pk PRIMARY KEY (id)
 );
-INSERT INTO public.brc20_indexer_version (indexer_version, db_version) VALUES ('opi-brc20-full-node v0.3.0', 3);
+INSERT INTO public.brc20_indexer_version (indexer_version, db_version) VALUES ('opi-brc20-full-node v0.4.0', 4);

--- a/modules/brc20_index/db_init.sql
+++ b/modules/brc20_index/db_init.sql
@@ -45,6 +45,7 @@ CREATE TABLE public.brc20_tickers (
 	decimals int4 NOT NULL,
 	limit_per_mint numeric(40) NOT NULL,
 	remaining_supply numeric(40) NOT NULL,
+	burned_supply numeric(40) NOT NULL,
 	is_self_mint boolean NOT NULL,
 	deploy_inscription_id text NOT NULL,
 	block_height int4 NOT NULL,

--- a/modules/brc20_index/db_init.sql
+++ b/modules/brc20_index/db_init.sql
@@ -78,6 +78,7 @@ CREATE TABLE public.brc20_indexer_version (
 	id bigserial NOT NULL,
 	indexer_version text NOT NULL,
 	db_version int4 NOT NULL,
+	event_hash_version int4 NOT NULL,
 	CONSTRAINT brc20_indexer_version_pk PRIMARY KEY (id)
 );
-INSERT INTO public.brc20_indexer_version (indexer_version, db_version) VALUES ('opi-brc20-full-node v0.4.0', 4);
+INSERT INTO public.brc20_indexer_version (indexer_version, db_version) VALUES ('opi-brc20-full-node v0.4.0', 4, 2);

--- a/modules/brc20_index/db_init_extra.sql
+++ b/modules/brc20_index/db_init_extra.sql
@@ -2,7 +2,7 @@ CREATE TABLE public.brc20_current_balances (
 	id bigserial NOT NULL,
 	pkscript text NOT NULL,
 	wallet text NULL,
-	tick varchar(4) NOT NULL,
+	tick text NOT NULL,
 	overall_balance numeric(40) NOT NULL,
 	available_balance numeric(40) NOT NULL,
 	block_height int4 NOT NULL,
@@ -17,7 +17,7 @@ CREATE INDEX brc20_current_balances_wallet_idx ON public.brc20_current_balances 
 CREATE TABLE public.brc20_unused_tx_inscrs (
 	id bigserial NOT NULL,
 	inscription_id text NOT NULL,
-	tick varchar(4) NOT NULL,
+	tick text NOT NULL,
 	amount numeric(40) NOT NULL,
 	current_holder_pkscript text NOT NULL,
 	current_holder_wallet text NULL,

--- a/modules/main_index/db_init.sql
+++ b/modules/main_index/db_init.sql
@@ -75,6 +75,14 @@ CREATE TABLE public.ord_network_type (
 	CONSTRAINT ord_network_type_pk PRIMARY KEY (id)
 );
 
+CREATE TABLE public.ord_transfer_counts (
+	id bigserial NOT NULL,
+	event_type text NOT NULL,
+	max_transfer_cnt int4 NOT NULL,
+	CONSTRAINT ord_transfer_counts_pk PRIMARY KEY (id)
+);
+CREATE UNIQUE INDEX ord_transfer_counts_event_type_idx ON public.ord_transfer_counts USING btree (event_type);
+
 CREATE TABLE public.ord_indexer_version (
 	id bigserial NOT NULL,
 	indexer_version text NOT NULL,

--- a/modules/main_index/db_init.sql
+++ b/modules/main_index/db_init.sql
@@ -89,4 +89,4 @@ CREATE TABLE public.ord_indexer_version (
 	db_version int4 NOT NULL,
 	CONSTRAINT ord_indexer_version_pk PRIMARY KEY (id)
 );
-INSERT INTO public.ord_indexer_version (indexer_version, db_version) VALUES ('OPI V0.3.1', 4);
+INSERT INTO public.ord_indexer_version (indexer_version, db_version) VALUES ('OPI V0.3.2', 5);

--- a/modules/main_index/db_init.sql
+++ b/modules/main_index/db_init.sql
@@ -18,6 +18,7 @@ CREATE TABLE public.ord_number_to_id (
 	inscription_number int8 NOT NULL,
 	inscription_id text NOT NULL,
 	cursed_for_brc20 bool NOT NULL,
+	parent_id text NULL,
 	block_height int4 NOT NULL,
 	CONSTRAINT ord_number_to_id_pk PRIMARY KEY (id)
 );
@@ -89,4 +90,4 @@ CREATE TABLE public.ord_indexer_version (
 	db_version int4 NOT NULL,
 	CONSTRAINT ord_indexer_version_pk PRIMARY KEY (id)
 );
-INSERT INTO public.ord_indexer_version (indexer_version, db_version) VALUES ('OPI V0.3.2', 5);
+INSERT INTO public.ord_indexer_version (indexer_version, db_version) VALUES ('OPI V0.4.0', 6);

--- a/modules/main_index/db_reset.sql
+++ b/modules/main_index/db_reset.sql
@@ -6,3 +6,4 @@ drop table if exists ord_indexer_reorg_stats;
 drop table if exists ord_indexer_work_stats;
 drop table if exists ord_indexer_version;
 drop table if exists ord_network_type;
+drop table if exists ord_transfer_counts;

--- a/modules/main_index/index.js
+++ b/modules/main_index/index.js
@@ -14,7 +14,7 @@ const readline = require('readline');
 
 bitcoin.initEccLib(ecc)
 
-console.log("VERSION V0.3.0")
+console.log("VERSION V0.3.2")
 
 // for self-signed cert of postgres
 process.env["NODE_TLS_REJECT_UNAUTHORIZED"] = 0;
@@ -99,7 +99,7 @@ async function check_db_max_transfer_cnts() {
 
   if (Object.keys(max_transfer_cnts_db).length == 0) {
     console.log("max_transfer_cnts not found in db, getting from ord")
-    
+
     let ord_max_transfer_cnts_cmd = ord_binary + " max-transfer-counts"
     let max_transfer_cnts_string = execSync(ord_max_transfer_cnts_cmd).toString()
     let max_transfer_cnts = JSON.parse(max_transfer_cnts_string)

--- a/modules/main_index/index.js
+++ b/modules/main_index/index.js
@@ -99,6 +99,9 @@ async function check_db_max_transfer_cnts() {
 
   if (Object.keys(max_transfer_cnts_db).length == 0) {
     console.log("max_transfer_cnts not found in db, getting from ord")
+    
+    let current_directory = process.cwd()
+    process.chdir(ord_folder);
 
     let ord_max_transfer_cnts_cmd = ord_binary + " max-transfer-counts"
     let max_transfer_cnts_string = execSync(ord_max_transfer_cnts_cmd).toString()
@@ -107,6 +110,8 @@ async function check_db_max_transfer_cnts() {
       console.error("max_transfer_cnts not found in ord!! check ord code!!")
       process.exit(1)
     }
+
+    process.chdir(current_directory);
 
     for (const [key, value] of Object.entries(max_transfer_cnts)) {
       await db_pool.query(`INSERT INTO ord_transfer_counts (event_type, max_transfer_cnt) VALUES ($1, $2);`, [key, value])

--- a/modules/main_index/index.js
+++ b/modules/main_index/index.js
@@ -98,6 +98,8 @@ async function check_db_max_transfer_cnts() {
   }
 
   if (Object.keys(max_transfer_cnts_db).length == 0) {
+    console.log("max_transfer_cnts not found in db, getting from ord")
+    
     let ord_max_transfer_cnts_cmd = ord_binary + " max-transfer-counts"
     let max_transfer_cnts_string = execSync(ord_max_transfer_cnts_cmd).toString()
     let max_transfer_cnts = JSON.parse(max_transfer_cnts_string)

--- a/modules/restore.py
+++ b/modules/restore.py
@@ -180,12 +180,13 @@ if not download_only and (restore_main_db or restore_brc20_db or restore_bitmap_
     exit()
 
 
-OBJECT_STORAGE_REGION = 'sfo3'
 OBJECT_STORAGE_BUCKET = 'opi-backups'
 
 s3config = {
-    "region_name": OBJECT_STORAGE_REGION,
-    "endpoint_url": "https://{}.digitaloceanspaces.com".format(OBJECT_STORAGE_REGION) }
+  "endpoint_url": "http://s3.opi.network:9000",
+  "aws_session_token": None,
+  "verify": False
+}
 
 s3client = boto3.client('s3', **s3config, config=Config(signature_version=UNSIGNED))
 def get_backup_filenames():

--- a/modules/restore.py
+++ b/modules/restore.py
@@ -195,7 +195,7 @@ def get_backup_filenames():
     res.append(key['Key'])
   return res
 
-S3_KEY_PREFIX = 'db_3/'
+S3_KEY_PREFIX = 'db_4/'
 def s3_download(s3_bucket, s3_object_key, local_file_name):
   s3_object_key = S3_KEY_PREFIX + s3_object_key
   meta_data = s3client.head_object(Bucket=s3_bucket, Key=s3_object_key)

--- a/modules/sns_index/sns_index.py
+++ b/modules/sns_index/sns_index.py
@@ -369,7 +369,7 @@ if cur.rowcount == 0:
 else:
   db_version = cur.fetchone()[0]
   if db_version != DB_VERSION:
-    print("This version (" + db_version + ") cannot be fixed, please run reset_init.py")
+    print("This version (" + str(db_version) + ") cannot be fixed, please run reset_init.py")
     exit(1)
 
 def try_to_report_with_retries(to_send):

--- a/modules/sns_index/sns_index.py
+++ b/modules/sns_index/sns_index.py
@@ -84,6 +84,23 @@ if network_type_db != network_type:
   print("network_type mismatch between main index and bitmap index")
   sys.exit(1)
 
+cur_metaprotocol.execute('SELECT event_type, max_transfer_cnt from ord_transfer_counts;')
+if cur_metaprotocol.rowcount == 0:
+  print("ord_transfer_counts not found, please run index.js in main_index to fix db")
+  sys.exit(1)
+
+default_max_transfer_cnt = 0
+tx_limits = cur_metaprotocol.fetchall()
+for tx_limit in tx_limits:
+  if tx_limit[0] == 'default':
+    default_max_transfer_cnt = tx_limit[1]
+    break
+
+if default_max_transfer_cnt < 1:
+  print("default max_transfer_cnt is less than 1, sns_indexer requires at least 1, please recreate db from scratch and rerun ord with default tx limit set to 1 or more")
+  sys.exit(1)
+
+
 ## helper functions
 def utf8len(s):
   return len(s.encode('utf-8'))

--- a/ord/Cargo.lock
+++ b/ord/Cargo.lock
@@ -2142,7 +2142,7 @@ dependencies = [
 
 [[package]]
 name = "opi-ord"
-version = "0.14.0-3"
+version = "0.14.0-4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/ord/Cargo.lock
+++ b/ord/Cargo.lock
@@ -2142,7 +2142,7 @@ dependencies = [
 
 [[package]]
 name = "opi-ord"
-version = "0.14.0-2"
+version = "0.14.0-3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/ord/Cargo.toml
+++ b/ord/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "opi-ord"
 description = "◉ Ordinal wallet and block explorer"
-version = "0.14.0-3"
+version = "0.14.0-4"
 license = "CC0-1.0"
 edition = "2021"
 autotests = false

--- a/ord/Cargo.toml
+++ b/ord/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "opi-ord"
 description = "◉ Ordinal wallet and block explorer"
-version = "0.14.0-2"
+version = "0.14.0-3"
 license = "CC0-1.0"
 edition = "2021"
 autotests = false

--- a/ord/src/index.rs
+++ b/ord/src/index.rs
@@ -38,6 +38,8 @@ mod reorg;
 mod rtx;
 mod updater;
 
+pub use updater::get_tx_limits;
+
 #[cfg(test)]
 pub(crate) mod testing;
 

--- a/ord/src/index/entry.rs
+++ b/ord/src/index/entry.rs
@@ -194,6 +194,7 @@ pub(crate) struct InscriptionEntry {
   pub(crate) timestamp: u32,
   pub(crate) is_json_or_text: bool,
   pub(crate) is_cursed_for_brc20: bool,
+  pub(crate) txcnt_limit: i16,
 }
 
 pub(crate) type InscriptionEntryValue = (
@@ -208,6 +209,7 @@ pub(crate) type InscriptionEntryValue = (
   u32,                // timestamp
   i8,                 // is_json_or_text
   i8,                 // is_cursed_for_brc20
+  i16,                // txcnt_limit
 );
 
 impl Entry for InscriptionEntry {
@@ -227,6 +229,7 @@ impl Entry for InscriptionEntry {
       timestamp,
       is_json_or_text,
       is_cursed_for_brc20,
+      txcnt_limit,
     ): InscriptionEntryValue,
   ) -> Self {
     Self {
@@ -241,6 +244,7 @@ impl Entry for InscriptionEntry {
       timestamp,
       is_json_or_text: is_json_or_text != 0,
       is_cursed_for_brc20: is_cursed_for_brc20 != 0,
+      txcnt_limit,
     }
   }
 
@@ -257,6 +261,7 @@ impl Entry for InscriptionEntry {
       self.timestamp,
       if self.is_json_or_text { 1 } else { 0 },
       if self.is_cursed_for_brc20 { 1 } else { 0 },
+      self.txcnt_limit,
     )
   }
 }

--- a/ord/src/index/updater.rs
+++ b/ord/src/index/updater.rs
@@ -1,5 +1,5 @@
 use {
-  self::{inscription_updater::InscriptionUpdater, rune_updater::RuneUpdater},
+  self::{inscription_updater::InscriptionUpdater, inscription_updater::TX_LIMITS, rune_updater::RuneUpdater},
   super::{fetcher::Fetcher, *},
   futures::future::try_join_all,
   std::sync::mpsc,
@@ -10,6 +10,14 @@ use std::fs::File;
 
 mod inscription_updater;
 mod rune_updater;
+
+pub fn get_tx_limits() -> HashMap<String, i16> {
+  let mut tx_limits = HashMap::new();
+  for (key, value) in TX_LIMITS.iter() {
+    tx_limits.insert(key.to_string(), *value);
+  }
+  tx_limits
+}
 
 pub(crate) struct BlockData {
   pub(crate) header: Header,

--- a/ord/src/index/updater/inscription_updater.rs
+++ b/ord/src/index/updater/inscription_updater.rs
@@ -25,8 +25,13 @@ pub(super) struct Flotsam<'a> {
   tx_option: Option<&'a Transaction>,
 }
 
-// tracking first 2 transfers is enough for brc-20 metaprotocol
-const INDEX_TX_LIMIT : i64 = 2;
+lazy_static! {
+  pub static ref TX_LIMITS: HashMap<String, i16> = {
+      let mut m = HashMap::<String, i16>::new();
+      m.insert("default".into(), 2);
+      m
+  };
+}
 
 #[derive(Debug, Clone)]
 enum Origin {
@@ -450,11 +455,17 @@ impl<'a, 'db, 'tx> InscriptionUpdater<'a, 'db, 'tx> {
     unreachable!()
   }
 
-  fn is_json(inscription_content_option: &Option<Vec<u8>>) -> bool {
-    if inscription_content_option.is_none() { return false; }
+  fn get_json_tx_limit(inscription_content_option: &Option<Vec<u8>>) -> i16 {
+    if inscription_content_option.is_none() { return 0; }
     let inscription_content = inscription_content_option.as_ref().unwrap();
 
-    return serde_json::from_slice::<Value>(&inscription_content).is_ok();
+    let json = serde_json::from_slice::<Value>(&inscription_content);
+    if json.is_err() {
+      return 0;
+    } else {
+      // check for event type and return tx limit
+      return TX_LIMITS["default"];
+    }
   }
 
   fn is_text(inscription_content_type_option: &Option<Vec<u8>>) -> bool {
@@ -526,9 +537,7 @@ impl<'a, 'db, 'tx> InscriptionUpdater<'a, 'db, 'tx> {
     let txcnt_of_inscr: i64 = self.id_to_txcnt.get(&inscription_id.store())?
         .map(|txcnt| txcnt.value())
         .unwrap_or(0) + 1;
-    if txcnt_of_inscr <= INDEX_TX_LIMIT { // only track first two transactions
-      self.id_to_txcnt.insert(&inscription_id.store(), &txcnt_of_inscr)?;
-    }
+    self.id_to_txcnt.insert(&inscription_id.store(), &txcnt_of_inscr)?;
 
     let (unbound, sequence_number) = match flotsam.origin {
       Origin::Old { old_satpoint } => {
@@ -547,7 +556,8 @@ impl<'a, 'db, 'tx> InscriptionUpdater<'a, 'db, 'tx> {
           .map(|entry| InscriptionEntry::load(entry.value()))
           .unwrap();
         let is_json_or_text = entry.is_json_or_text;
-        if is_json_or_text && txcnt_of_inscr <= INDEX_TX_LIMIT { // only track non-cursed and first two transactions
+        let txcnt_limit = entry.txcnt_limit;
+        if is_json_or_text && txcnt_of_inscr <= txcnt_limit.into() { // only track non-cursed and first two transactions
           self.write_to_file(format!("cmd;{0};insert;transfer;{1};{old_satpoint};{new_satpoint};{send_to_coinbase};{2};{3}", 
                     self.height, flotsam.inscription_id, 
                     hex::encode(new_script_pubkey.unwrap_or(&ScriptBuf::new()).clone().into_bytes()), 
@@ -596,11 +606,12 @@ impl<'a, 'db, 'tx> InscriptionUpdater<'a, 'db, 'tx> {
         let inscription_content = inscription.body;
         let inscription_content_type = inscription.content_type;
         let inscription_metaprotocol = inscription.metaprotocol;
-        let is_json = Self::is_json(&inscription_content);
+        let json_txcnt_limit = Self::get_json_tx_limit(&inscription_content);
+        let is_json = json_txcnt_limit > 0;
         let is_text = Self::is_text(&inscription_content_type);
         let is_json_or_text = is_json || is_text;
         
-        if !unbound && is_json_or_text {
+        let txcnt_limit = if !unbound && is_json_or_text {
           self.write_to_file(format!("cmd;{0};insert;number_to_id;{1};{2};{3}", self.height, inscription_number, flotsam.inscription_id, if cursed_for_brc20 {"1"} else {"0"}), false)?;
           // write content as minified json
           if is_json {
@@ -610,14 +621,20 @@ impl<'a, 'db, 'tx> InscriptionUpdater<'a, 'db, 'tx> {
             let inscription_metaprotocol_str = hex::encode(inscription_metaprotocol.unwrap_or(Vec::new()));
             self.write_to_file(format!("cmd;{0};insert;content;{1};{2};{3};{4};{5}", 
                                     self.height, flotsam.inscription_id, is_json, inscription_content_type_str, inscription_metaprotocol_str, inscription_content_json_str), false)?;
+            
+            json_txcnt_limit
           } else {
             let inscription_content_hex_str = hex::encode(inscription_content.unwrap_or(Vec::new()));
             let inscription_content_type_str = hex::encode(inscription_content_type.unwrap_or(Vec::new()));
             let inscription_metaprotocol_str = hex::encode(inscription_metaprotocol.unwrap_or(Vec::new()));
             self.write_to_file(format!("cmd;{0};insert;content;{1};{2};{3};{4};{5}", 
                                     self.height, flotsam.inscription_id, is_json, inscription_content_type_str, inscription_metaprotocol_str, inscription_content_hex_str), false)?;
+            
+            TX_LIMITS["default"]
           }
-        }
+        } else {
+          0
+        };
 
         let sat = if unbound {
           None
@@ -695,6 +712,7 @@ impl<'a, 'db, 'tx> InscriptionUpdater<'a, 'db, 'tx> {
             timestamp: self.timestamp,
             is_json_or_text,
             is_cursed_for_brc20: cursed_for_brc20,
+            txcnt_limit,
           }
           .store(),
         )?;

--- a/ord/src/index/updater/inscription_updater.rs
+++ b/ord/src/index/updater/inscription_updater.rs
@@ -612,7 +612,7 @@ impl<'a, 'db, 'tx> InscriptionUpdater<'a, 'db, 'tx> {
         let is_json_or_text = is_json || is_text;
         
         let txcnt_limit = if !unbound && is_json_or_text {
-          self.write_to_file(format!("cmd;{0};insert;number_to_id;{1};{2};{3}", self.height, inscription_number, flotsam.inscription_id, if cursed_for_brc20 {"1"} else {"0"}), false)?;
+          self.write_to_file(format!("cmd;{0};insert;number_to_id;{1};{2};{3};{4}", self.height, inscription_number, flotsam.inscription_id, if cursed_for_brc20 {"1"} else {"0"}, parent.map(|p| p.to_string()).unwrap_or(String::from(""))), false)?;
           // write content as minified json
           if is_json {
             let inscription_content_json = serde_json::from_slice::<Value>(&(inscription_content.unwrap())).unwrap();

--- a/ord/src/subcommand.rs
+++ b/ord/src/subcommand.rs
@@ -16,6 +16,8 @@ pub mod teleburn;
 pub mod traits;
 pub mod wallet;
 
+use crate::index::get_tx_limits;
+
 #[derive(Debug, Parser)]
 pub(crate) enum Subcommand {
   #[command(about = "List all rune balances")]
@@ -48,6 +50,14 @@ pub(crate) enum Subcommand {
   Traits(traits::Traits),
   #[command(about = "Wallet commands")]
   Wallet(wallet::Wallet),
+  #[command(about = "List max transfer counts")]
+  MaxTransferCounts,
+}
+
+fn max_transfer_counts() -> SubcommandResult {
+  // create a dictionary. set 'default' to 2 and 'brc20-approve-conditional' to 5
+  let max_transfer_counts = get_tx_limits();
+  Ok(Box::new(max_transfer_counts))
 }
 
 impl Subcommand {
@@ -73,6 +83,7 @@ impl Subcommand {
       Self::Teleburn(teleburn) => teleburn.run(),
       Self::Traits(traits) => traits.run(),
       Self::Wallet(wallet) => wallet.run(options),
+      Self::MaxTransferCounts => max_transfer_counts(),
     }
   }
 }


### PR DESCRIPTION
- The old version tracked 2 hops for every JSON&Text inscription. With this version we added optional configuration to ord to track different types of inscriptions with different hop counts. This was needed since brc20-swap implementation uses several kinds of inscriptions with more than two hops.
- Added original_ticker tracking to brc20
- Implemented self-mint proposal (https://github.com/brc20-devs/brc20-proposals/blob/main/bp04-self-mint/proposal.md)
- Implemented burn proposal (https://github.com/brc20-devs/brc20-proposals/blob/main/bp05-burn/proposal.md)
- Improved the performance of brc20 indexing by around 6x via using batched inserts.

This version changed brc20 hash calculation method due to added new fields.
This version added new information to main index db so a full reindex will be needed after update